### PR TITLE
Fix border_style for PopupMessage

### DIFF
--- a/src/popup_message.rs
+++ b/src/popup_message.rs
@@ -81,6 +81,7 @@ impl Widget for PopupMessage<'_, '_> {
 			.title_alignment(self.title_alignment)
 			.borders(self.borders)
 			.border_type(self.border_type)
+			.border_style(self.border_style)
 			.padding(self.padding)
 			.bg(self.bg);
 


### PR DESCRIPTION
`border_style` currently doesn't work for PopupMessage because it's not used.