### PR TITLE
chore: bump crate versions and remove deprecated size implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ default = ["crossterm"]
 crossterm = ["dep:crossterm"]
 
 [dependencies]
-ratatui = { version = "0.28.0", features = ["all-widgets"] }
+ratatui = { version = "0.29.0", features = ["all-widgets"] }
 rand = "0.8.5"
 crossterm = { version = "0.28.1", optional = true }
-regex = "1.10.6"
+regex = "1.11.1"
 
 [[example]]
 name = "confirm"

--- a/examples/confirm.rs
+++ b/examples/confirm.rs
@@ -94,7 +94,7 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
 }
 
 fn ui(f: &mut Frame, app: &mut App) {
-	let area = f.size();
+	let area = f.area();
 
 	let vertical = Layout::default()
 		.direction(Direction::Vertical)

--- a/examples/popup.rs
+++ b/examples/popup.rs
@@ -60,7 +60,7 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
 }
 
 fn ui(f: &mut Frame, app: &mut App) {
-	let area = f.size();
+	let area = f.area();
 
 	let vertical = Layout::default()
 		.direction(Direction::Vertical)


### PR DESCRIPTION
so i just updated the crates
```rs

name    old req compatible latest new req
====    ======= ========== ====== =======
ratatui 0.28.0  0.28.1     0.29.0 0.29.0
regex   1.10.6  1.11.1     1.11.1 1.11.1
```
and in the example code removed the size implementation and changed it to area as size is no deprecated. Also changed the version number if this gets accepted