### PR TITLE
More ratatui 0.30.0 updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ default = ["crossterm"]
 crossterm = ["dep:ratatui"]
 
 [dependencies]
-ratatui = { version = "0.30.0", features = ["all-widgets"], optional = true }
+ratatui-core = { version = "0.1.0", default-features = false }
+ratatui-widgets = { version = "0.3.0", default-features = false }
+ratatui = { version = "0.30.0", default-features = false, features = ["crossterm"], optional = true }
 rand = "0.9.0"
 regex = "1.11.1"
 

--- a/examples/popup.rs
+++ b/examples/popup.rs
@@ -1,10 +1,6 @@
 use std::{error::Error, io};
 
-use ratatui::crossterm::{
-    event::{self, Event, KeyCode, KeyEventKind},
-    execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
+use ratatui::crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use ratatui::text::Line;
 use ratatui::{prelude::*, widgets::*};
 
@@ -20,21 +16,9 @@ impl App {
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
-    // setup terminal
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen)?;
-    let backend = CrosstermBackend::new(stdout);
-    let mut terminal = Terminal::new(backend)?;
-
     // create app and run it
     let app = App::new();
-    let res = run_app(&mut terminal, app);
-
-    // restore terminal
-    disable_raw_mode()?;
-    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
-    terminal.show_cursor()?;
+    let res = run_app(app);
 
     if let Err(err) = res {
         println!("{err:?}");
@@ -43,20 +27,20 @@ fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<()> {
-    loop {
-        terminal.draw(|f| ui(f, &mut app)).expect("panic message");
+fn run_app(mut app: App) -> io::Result<()> {
+    ratatui::run(|terminal| loop {
+        terminal.draw(|f| ui(f, &mut app)).expect("panic message");;
 
         if let Event::Key(key) = event::read()? {
             if key.kind == KeyEventKind::Press {
                 match key.code {
-                    KeyCode::Char('q') => return Ok(()),
+                    KeyCode::Char('q') => break Ok(()),
                     KeyCode::Char('p') => app.popup_opened = !app.popup_opened,
                     _ => {}
                 }
             }
         }
-    }
+    })
 }
 
 fn ui(f: &mut Frame, app: &mut App) {

--- a/src/confirm_dialog.rs
+++ b/src/confirm_dialog.rs
@@ -5,16 +5,17 @@ use std::sync::mpsc::Sender;
 use std::sync::LazyLock;
 
 use rand::random;
-use ratatui::buffer::Buffer;
 #[cfg(feature = "crossterm")]
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyEventKind};
-use ratatui::layout::{Alignment, Constraint, Layout, Rect};
-use ratatui::prelude::{Direction, Style, Text};
-use ratatui::style::{Color, Stylize};
-use ratatui::text::Line;
-use ratatui::widgets::{
-    Block, BorderType, Borders, Clear, Padding, Paragraph, StatefulWidget, Widget, Wrap,
-};
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::{Alignment, Constraint, Direction, Layout, Rect};
+use ratatui_core::style::{Color, Style, Stylize};
+use ratatui_core::text::{Line, Text};
+use ratatui_core::widgets::{StatefulWidget, Widget};
+use ratatui_widgets::block::{Block, Padding};
+use ratatui_widgets::borders::{BorderType, Borders};
+use ratatui_widgets::clear::Clear;
+use ratatui_widgets::paragraph::{Paragraph, Wrap};
 use regex::Regex;
 
 use crate::{ButtonLabel, ConfirmDialog, ConfirmDialogState, Listener, TryFromSliceError};

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,4 +1,4 @@
-use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui_core::layout::{Constraint, Direction, Layout, Rect};
 
 /// helper function to create a centered rect using up certain percentage of the available rect `r`
 #[allow(dead_code)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,11 @@
 
 use std::sync::mpsc::Sender;
 
-use ratatui::layout::Alignment;
-use ratatui::style::{Color, Style};
-use ratatui::text::{Line, Text};
-use ratatui::widgets::{BorderType, Borders, Padding};
+use ratatui_core::layout::Alignment;
+use ratatui_core::style::{Color, Style};
+use ratatui_core::text::{Line, Text};
+use ratatui_widgets::block::Padding;
+use ratatui_widgets::borders::{BorderType, Borders};
 
 mod confirm_dialog;
 pub mod helper;

--- a/src/popup_message.rs
+++ b/src/popup_message.rs
@@ -1,9 +1,13 @@
-use ratatui::buffer::Buffer;
-use ratatui::layout::{Alignment, Rect};
-use ratatui::prelude::{Color, Style};
-use ratatui::style::Stylize;
-use ratatui::text::{Line, Text};
-use ratatui::widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph, Widget};
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::{Alignment, Rect};
+use ratatui_core::style::Stylize;
+use ratatui_core::style::{Color, Style};
+use ratatui_core::text::{Line, Text};
+use ratatui_core::widgets::Widget;
+use ratatui_widgets::block::{Block, Padding};
+use ratatui_widgets::borders::{BorderType, Borders};
+use ratatui_widgets::clear::Clear;
+use ratatui_widgets::paragraph::Paragraph;
 
 use crate::PopupMessage;
 


### PR DESCRIPTION
This simplifies the examples by using the provided ratatui::run() function and switch the core data structure to the ratatui-core and ratatui-widgets crates which provide a more stable base for custom widgets.